### PR TITLE
CompatHelper: bump compat for "StatsBase" to "0.33"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ AbstractMCMC = "0.5.4"
 Clustering = "0.13"
 Distributions = "0.21,0.22,0.23"
 MCMCChains = "3"
-StatsBase = "0.32"
+StatsBase = "0.32, 0.33"
 StatsFuns = "0.9"
 julia = "1"
 


### PR DESCRIPTION
This pull request changes the compat entry for the `StatsBase` package from `0.32` to `0.32, 0.33`.

This keeps the compat entries for earlier versions.

Note: I have not tested your package with this new compat entry. It is your responsibility to make sure that your package tests pass before you merge this pull request.