### PR TITLE
CompatHelper: bump compat for "AbstractMCMC" to "1.0"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 
 [compat]
-AbstractMCMC = "0.5.4"
+AbstractMCMC = "0.5.4, 1.0"
 Clustering = "0.13"
 Distributions = "0.21,0.22,0.23"
 MCMCChains = "3"


### PR DESCRIPTION
This pull request changes the compat entry for the `AbstractMCMC` package from `0.5.4` to `0.5.4, 1.0`.

This keeps the compat entries for earlier versions.

Note: I have not tested your package with this new compat entry. It is your responsibility to make sure that your package tests pass before you merge this pull request.