### PR TITLE
support regions with constant zero likelihood

### DIFF
--- a/src/step.jl
+++ b/src/step.jl
@@ -92,7 +92,7 @@ function step(rng, model, sampler, state; kwargs...)
     logz = logaddexp(state.logz, logwt)
     h = (exp(logwt - logz) * logl_dead +
          exp(state.logz - logz) * (state.h + state.logz) - logz)
-    logzerr = sqrt(h / sampler.nactive)
+    logzerr = h >= 0 ? sqrt(h / sampler.nactive) : NaN
     logvol = state.logvol - 1 / sampler.nactive
 
     ## prepare returns

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -23,6 +23,15 @@
     @test size(chains3, 2) == size(val_arr3, 2)
 end
 
+@testset "Zero likelihood" begin
+    logl(x::AbstractVector) = x[1] > 0 ? exp(-x[1]^2 / 2) / √(2π) : -Inf
+    priors = [Uniform(-1, 1)]
+    model = NestedModel(logl, priors)
+    spl = Nested(1, 500)
+    chains, _ = sample(rng, model, spl; param_names=["x"])
+    @test all(>(0), chains[:x][chains[:weights] .> 1e-10])
+end
+
 @testset "Stopping criterion" begin
     logl(x::AbstractVector) =  exp(-x[1]^2 / 2) / √(2π)
     priors = [Uniform(-1, 1)]


### PR DESCRIPTION
It just failed at sqrt(negative value) before.
See https://github.com/joshspeagle/dynesty/blob/020daa0dae04aa12a314de5f30ab920ddfc615a9/py/dynesty/results.py#L125-L126 for how it's done in dynesty.