### PR TITLE
rename Uniform -> Rejection

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -33,7 +33,7 @@ Bounds.MultiEllipsoid
 ```@docs
 Proposals
 Proposals.AbstractProposal
-Proposals.Uniform
+Proposals.Rejection
 Proposals.RWalk
 Proposals.RStagger
 Proposals.Slice

--- a/src/proposals/Proposals.jl
+++ b/src/proposals/Proposals.jl
@@ -4,7 +4,7 @@
 This module contains the different algorithms for proposing new points within a bounding volume in unit space.
 
 The available implementations are
-* [`Proposals.Uniform`](@ref) - samples uniformly within the bounding volume
+* [`Proposals.Rejection`](@ref) - samples uniformly within the bounding volume
 * [`Proposals.RWalk`](@ref) - random walks to a new point given an existing one
 * [`Proposals.RStagger`](@ref) - random staggering away to a new point given an existing one
 * [`Proposals.Slice`](@ref) - slicing away to a new point given an existing one
@@ -41,18 +41,20 @@ abstract type AbstractProposal end
 unitcheck(us) = all(u -> 0 < u < 1, us)
 
 """
-    Proposals.Uniform(;maxiter=100_000)
+    Proposals.Rejection(;maxiter=100_000)
 
-Propose a new live point by uniformly sampling within the bounding volume.
+Propose a new live point by uniformly sampling within the bounding volume and rejecting samples that do not meet the likelihood constraints.
 
 ## Parameters
 - `maxiter` is the maximum number of samples that can be rejected before giving up and throwing an error.
 """
-Base.@kwdef struct Uniform <: AbstractProposal
+Base.@kwdef struct Rejection <: AbstractProposal
     maxiter::Int = 100_000
 end
 
-function (prop::Uniform)(rng::AbstractRNG,
+@deprecate Uniform() Rejection()
+
+function (prop::Rejection)(rng::AbstractRNG,
     point::AbstractVector,
     logl_star,
     bounds::AbstractBoundingSpace,
@@ -71,7 +73,7 @@ function (prop::Uniform)(rng::AbstractRNG,
     throw(ErrorException("Couldn't generate a proper point after $(prop.maxiter) attempts including $ncall likelihood calls. Bounds=$bounds, logl_star=$logl_star."))
 end
 
-Base.show(io::IO, p::Uniform) = print(io, "NestedSamplers.Proposals.Uniform")
+Base.show(io::IO, p::Rejection) = print(io, "NestedSamplers.Proposals.Rejection")
 
 """
     Proposals.RWalk(;ratio=0.5, walks=25, scale=1)

--- a/src/staticsampler.jl
+++ b/src/staticsampler.jl
@@ -28,16 +28,16 @@ Static nested sampler with `nactive` active points and `ndims` parameters.
 ## Bounds and Proposals
 
 `bounds` declares the Type of [`Bounds.AbstractBoundingSpace`](@ref) to use in the prior volume. The available bounds are described by [`Bounds`](@ref). `proposal` declares the algorithm used for proposing new points. The available proposals are described in [`Proposals`](@ref). If `proposal` is `:auto`, will choose the proposal based on `ndims`
-* `ndims < 10` - [`Proposals.Uniform`](@ref)
+* `ndims < 10` - [`Proposals.Rejection`](@ref)
 * `10 ≤ ndims ≤ 20` - [`Proposals.RWalk`](@ref)
 * `ndims > 20` - [`Proposals.Slice`](@ref)
 
-The original nested sampling algorithm is roughly equivalent to using `Bounds.Ellipsoid` with `Proposals.Uniform`. The MultiNest algorithm is roughly equivalent to `Bounds.MultiEllipsoid` with `Proposals.Uniform`. The PolyChord algorithm is roughly equivalent to using `Proposals.RSlice`.
+The original nested sampling algorithm is roughly equivalent to using `Bounds.Ellipsoid` with `Proposals.Rejection`. The MultiNest algorithm is roughly equivalent to `Bounds.MultiEllipsoid` with `Proposals.Rejection`. The PolyChord algorithm is roughly equivalent to using `Proposals.RSlice`.
 
 ## Other Parameters
 * `enlarge` - When fitting the bounds to live points, they will be enlarged (in terms of volume) by this linear factor.
 * `update_interval` - How often to refit the live points with the bounds as a fraction of `nactive`. By default this will be determined using `default_update_interval` for the given proposal
-    * `Proposals.Uniform` - `1.5`
+    * `Proposals.Rejection` - `1.5`
     * `Proposals.RWalk` and `Proposals.RStagger` - `0.15 * walks`
     * `Proposals.Slice` - `0.9 * ndims * slices`
     * `Proposals.RSlice` - `2 * slices`
@@ -58,7 +58,7 @@ function Nested(ndims,
     # get proposal
     if proposal === :auto
         proposal = if ndims < 10
-            Proposals.Uniform()
+            Proposals.Rejection()
         elseif 10 ≤ ndims ≤ 20
             Proposals.RWalk() 
         else
@@ -81,7 +81,7 @@ function Nested(ndims,
         dlv)
 end
 
-default_update_interval(p::Proposals.Uniform, ndims) = 1.5
+default_update_interval(p::Proposals.Rejection, ndims) = 1.5
 default_update_interval(p::Proposals.RWalk, ndims) = 0.15 * p.walks
 default_update_interval(p::Proposals.RStagger, ndims) = 0.15 * p.walks
 default_update_interval(p::Proposals.Slice, ndims) = 0.9 * ndims * p.slices

--- a/src/step.jl
+++ b/src/step.jl
@@ -16,7 +16,7 @@ function step(rng, model, sampler::Nested; kwargs...)
     # sample a new live point without bounds
     point = rand(rng, eltype(us), sampler.ndims)
     bound = Bounds.fit(Bounds.NoBounds, us)
-    proposal = Proposals.Uniform()
+    proposal = Proposals.Rejection()
     u, v, ll, nc = proposal(rng, v_dead, logl_dead, bound, model.loglike, model.prior_transform)
 
     us[:, idx_dead] .= u
@@ -79,7 +79,7 @@ function step(rng, model, sampler, state; kwargs...)
     else
         point = rand(rng, eltype(state.us), sampler.ndims)
         bound = Bounds.fit(Bounds.NoBounds, state.us)
-        proposal = Proposals.Uniform()
+        proposal = Proposals.Rejection()
         u, v, logl, nc = proposal(rng, point, logl_dead, bound, model.loglike, model.prior_transform)
     end
 

--- a/test/deprecations.jl
+++ b/test/deprecations.jl
@@ -1,0 +1,5 @@
+
+@testset "Proposals.Uniform -> Proposals.Rejection deprecation" begin
+    prop = @test_deprecated Proposals.Uniform()
+    @test prop === Proposals.Rejection()
+end

--- a/test/models.jl
+++ b/test/models.jl
@@ -1,5 +1,5 @@
 const test_bounds = [Bounds.Ellipsoid, Bounds.MultiEllipsoid]
-const test_props = [Proposals.Uniform(), Proposals.RWalk(ratio=0.9, walks=50), Proposals.RStagger(ratio=0.9, walks=75), Proposals.Slice(slices=10), Proposals.RSlice()]
+const test_props = [Proposals.Rejection(), Proposals.RWalk(ratio=0.9, walks=50), Proposals.RStagger(ratio=0.9, walks=75), Proposals.Slice(slices=10), Proposals.RSlice()]
 
 
 @testset "$(nameof(bound)), $(nameof(typeof(proposal)))" for bound in test_bounds, proposal in test_props

--- a/test/proposals/proposals.jl
+++ b/test/proposals/proposals.jl
@@ -1,5 +1,5 @@
 const PROPOSALS = [
-    Proposals.Uniform(),
+    Proposals.Rejection(),
     Proposals.RWalk(),
     Proposals.RStagger(),
     Proposals.Slice(),
@@ -27,9 +27,9 @@ const BOUNDS = [
     @test logl(v) == logL ≥ loglstar
 end
 
-@testset "Uniform" begin
+@testset "Rejection" begin
     # printing
-    @test sprint(show, Proposals.Uniform()) == "NestedSamplers.Proposals.Uniform"
+    @test sprint(show, Proposals.Rejection()) == "NestedSamplers.Proposals.Rejection"
 end
 
 @testset "RWalk" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ AbstractMCMC.setprogress!(get(ENV, "CI", "false") == "false")
 
 include("utils.jl")
 
+@testset "Deprecations" begin include("deprecations.jl") end
 @testset "Bounds" begin include("bounds/bounds.jl") end
 @testset "Proposals" begin include("proposals/proposals.jl") end
 @testset "Sampler" begin include("sampler.jl") end

--- a/test/sampler.jl
+++ b/test/sampler.jl
@@ -1,7 +1,7 @@
 using NestedSamplers: default_update_interval
 
 @testset "default helpers" begin
-    @test default_update_interval(Proposals.Uniform(), 3) == 1.5
+    @test default_update_interval(Proposals.Rejection(), 3) == 1.5
     @test default_update_interval(Proposals.RWalk(), 10) == 3.75
     @test default_update_interval(Proposals.RWalk(walks=10), 10) == 1.5
     @test default_update_interval(Proposals.RStagger(), 10) == 3.75
@@ -13,7 +13,7 @@ using NestedSamplers: default_update_interval
 end
 
 spl = Nested(3, 100)
-@test spl.proposal isa Proposals.Uniform
+@test spl.proposal isa Proposals.Rejection
 @test spl.bounds == Bounds.MultiEllipsoid
 @test spl.update_interval == 150
 @test spl.enlarge == 1.25


### PR DESCRIPTION
I wanted to rename `Uniform` -> `Rejection` in the `Proposals` module because I think it is a better name. Despite this repo being pre-v1.0, I'll deprecate the `Uniform` constructor since I'm making a superficial change.
