### PR TITLE
Round out the 0.9.0 changelog entry

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,10 @@
 # 0.9.0
 
+The release that adds AbstractMCMC 5 support, asked for in #107.
+
 ## Breaking changes
 
-Requires Julia 1.10 and AbstractMCMC 5.10 or later.
+Requires Julia 1.10 and AbstractMCMC 5.10 or later. AbstractMCMC 3 and 4 are no longer supported.
 
 Sampling threw a `TypeError` on AbstractMCMC 5.10 and later, which swapped the boolean `progress` keyword for `AbstractProgressKwarg` instances. `nested_isdone` now reads it by type.
 
@@ -11,5 +13,7 @@ Sampling threw a `TypeError` on AbstractMCMC 5.10 and later, which swapped the b
 MCMCChains compat is now `"6, 7"`. Earlier versions cap AbstractMCMC below 5, so they cannot resolve anyway.
 
 ## Other changes
+
+The package moved from TuringLang to the chalk-lab organisation. Docs are now served from https://chalk-lab.github.io/NestedSamplers.jl.
 
 LogExpFunctions 1 and Parameters 0.13 are now allowed.


### PR DESCRIPTION
The 0.9.0 entry only covered the changes from #111. Everything else that landed since 0.8.3, the last registered release, was CI and docs infrastructure, apart from the move from TuringLang to chalk-lab, which is user facing because the docs URL changed. `src/` and `test/` were otherwise untouched between 0.8.3 and #111. Also leads with AbstractMCMC 5 support, since that is what the release was opened for in #107.